### PR TITLE
Adding test for actions!

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,16 @@
+workflow "Deploy ImageDefinition Schema" {
+  on = "push"
+  resolves = ["Extract ImageDefinition Schema"]
+}
+
+action "Extract ImageDefinition Schema" {
+  uses = "openschemas/extractors/ImageDefinition@master"
+  secrets = ["GITHUB_TOKEN"]
+  env = {
+    IMAGE_THUMBNAIL = "https://vsoch.github.io/datasets/assets/img/avocado.png"
+    IMAGE_ABOUT = "Generate ascii art for a fork or spoon, along with a pun."
+    IMAGE_DESCRIPTION = "alpine base with GoLang and PUNS."
+  }
+  args = ["extract", "--contact", "@vsoch", '--deploy']
+}
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 **@GodloveD**
 
-[![asciicast](https://asciinema.org/a/160642.png)](https://asciinema.org/a/160642?speed=2)
-
+[![asciicast](https://asciinema.org/a/160642.svg)](https://asciinema.org/a/160642?speed=2)
 
 ## Local Development
 You will need to install Go, and then have this repository in your src.


### PR DESCRIPTION
This PR will add the main workflow to test Github actions. Specifically, we want to parse metadata from the Dockerfile in the repo, and then extract software dependencies with container-diff, and finally, deploy the index.html back to Github pages. I'll likely need to do testing and debugging before this is working fully. 